### PR TITLE
Update Proguard configuration for codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,9 @@ Additional rules are needed if you are using Kotlin:
 ```
 *...If you are using the codegen API (i.e. `JsonClass(generateAdapter = true)`):*
 ```
--keepnames class **JsonAdapter
+-keep class **JsonAdapter {
+    <init>(...);
+}
 -keepnames @com.squareup.moshi.JsonClass class *
 ```
 


### PR DESCRIPTION
`-keepnames` will prevent Proguard from renaming the class during obfuscation phase but won't protect the class from code shrinking. ([source from Proguard manual](https://www.guardsquare.com/en/proguard/manual/usage#keepnames))
In most cases, the generated adapter classes are never referenced directly in the code as the adapters are loaded dynamically by Moshi.
This means that, for Proguard, the classes are unused and Proguard will remove them during the shrinking phase.

The adapters need to be kept as well as there primary constructor. This is the best configuration I figured out.

Thank you for this great new feature.